### PR TITLE
fix: remove infinite scroll on transaction list as it did not filter on selected month

### DIFF
--- a/apps/web/src/features/transactions/transactions.controller.ts
+++ b/apps/web/src/features/transactions/transactions.controller.ts
@@ -5,7 +5,6 @@ import {
   deleteTransactionSchema,
   getTransactionSchema,
   getTransactionsSchema,
-  listTransactionsSchema,
   linkTagToEntrySchema,
   saveTransactionSchema,
   updateTransactionSchema,
@@ -27,14 +26,6 @@ const getTransaction = createServerFn({ method: "GET" })
     const userId = context.user.id;
     const transactionId = data.transactionId;
     return await transactionService.getTransaction(userId, transactionId);
-  });
-
-const listTransactions = createServerFn({ method: "GET" })
-  .middleware([authenticated])
-  .inputValidator(listTransactionsSchema)
-  .handler(async ({ context, data }) => {
-    const userId = context.user.id;
-    return await transactionService.listTransactions(userId, data);
   });
 
 const getTransactionKpis = createServerFn({ method: "GET" })
@@ -117,7 +108,6 @@ const unlinkTagFromEntry = createServerFn({ method: "POST" })
 
 export const transactionController = {
   getTransactions,
-  listTransactions,
   getTransactionKpis,
   getTransaction,
   saveTransaction,

--- a/apps/web/src/features/transactions/transactions.dtos.ts
+++ b/apps/web/src/features/transactions/transactions.dtos.ts
@@ -10,11 +10,6 @@ export const getTransactionsSchema = z.object({
   month: z.number().optional(),
 });
 
-export const listTransactionsSchema = getTransactionsSchema.extend({
-  offset: z.coerce.number().int().min(0).optional(),
-  limit: z.coerce.number().int().min(1).max(50).optional(),
-});
-
 export const getTransactionSchema = z.object({
   transactionId: z.string(),
 });
@@ -66,7 +61,7 @@ export const updateTransactionSchema = z.object({
 
 export type UpdateTransactionDTO = z.infer<typeof updateTransactionSchema>;
 
-export type ListTransactionsDTO = z.infer<typeof listTransactionsSchema>;
+export type GetTransactionsDTO = z.infer<typeof getTransactionsSchema>;
 
 export const linkTagToEntrySchema = z.object({
   transactionId: z.string(),

--- a/apps/web/src/features/transactions/transactions.models.ts
+++ b/apps/web/src/features/transactions/transactions.models.ts
@@ -30,12 +30,6 @@ export type FullTransaction = Transaction & {
   })[];
 };
 
-export type TransactionPage = {
-  transactions: FullTransaction[];
-  nextOffset: number | null;
-  hasMore: boolean;
-};
-
 export type TransactionKpis = {
   count: number;
   averagePerDay: number;

--- a/apps/web/src/features/transactions/transactions.queries.ts
+++ b/apps/web/src/features/transactions/transactions.queries.ts
@@ -1,8 +1,7 @@
-import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 import { transactionController } from "./transactions.controller";
 
 export const TRANSACTION_QUERY_KEY = "transactions";
-const LIST_STALE_TIME_MS = 1000 * 60 * 5;
 
 function getTransactionsOptions(year?: number, month?: number) {
   return queryOptions({
@@ -14,31 +13,6 @@ function getTransactionsOptions(year?: number, month?: number) {
           month,
         },
       }),
-  });
-}
-
-function getTransactionListOptions(year?: number, month?: number) {
-  return infiniteQueryOptions({
-    queryKey: [TRANSACTION_QUERY_KEY, "list", year, month],
-    staleTime: LIST_STALE_TIME_MS,
-    initialPageParam: 0,
-    queryFn: ({ pageParam }) =>
-      transactionController.listTransactions({
-        data: {
-          year,
-          month,
-          offset: pageParam,
-          limit: 25,
-        },
-      }),
-    getNextPageParam: (lastPage) => {
-      const [error, data] = lastPage;
-      if (error || !data?.hasMore) {
-        return null;
-      }
-
-      return data.nextOffset;
-    },
   });
 }
 
@@ -65,7 +39,6 @@ function getTransactionOptions(transactionId: string) {
 
 export const transactionQueries = {
   getTransactionsOptions,
-  getTransactionListOptions,
   getTransactionKpisOptions,
   getTransactionOptions,
 };

--- a/apps/web/src/features/transactions/transactions.repo.ts
+++ b/apps/web/src/features/transactions/transactions.repo.ts
@@ -21,41 +21,10 @@ async function getAll(userId: string, start: Date, end: Date) {
       userId,
       date: { gte: start, lte: end },
     },
-  });
-}
-
-async function getPage(options: {
-  userId: string;
-  start: Date;
-  end: Date;
-  offset: number;
-  limit: number;
-}) {
-  return await db.query.transactions.findMany({
-    with: {
-      entries: {
-        with: {
-          products: {
-            with: {
-              tags: true,
-            },
-          },
-          tags: true,
-        },
-      },
-    },
-    where: (transaction, { and, eq, gte, lt }) =>
-      and(
-        eq(transaction.userId, options.userId),
-        gte(transaction.date, options.start),
-        lt(transaction.date, options.end),
-      ),
     orderBy: (transaction, { desc }) => [
       desc(transaction.date),
       desc(transaction.id),
     ],
-    limit: options.limit,
-    offset: options.offset,
   });
 }
 
@@ -165,7 +134,6 @@ async function removeAllEntryTagLinks(entryId: string) {
 
 export const transactionRepo = {
   getAll,
-  getPage,
   getKpis,
   getOne,
   save,

--- a/apps/web/src/features/transactions/transactions.service.test.ts
+++ b/apps/web/src/features/transactions/transactions.service.test.ts
@@ -9,7 +9,6 @@ import {
 vi.mock("./transactions.repo", () => ({
   transactionRepo: {
     getAll: vi.fn(),
-    getPage: vi.fn(),
     getKpis: vi.fn(),
     getOne: vi.fn(),
     save: vi.fn(),
@@ -141,66 +140,6 @@ describe("transactionService", () => {
       mockTransactionRepo.getKpis.mockRejectedValue(new Error("DB error"));
 
       const [error, data] = await transactionService.getTransactionKpis("user-1", {});
-
-      expect(data).toBeNull();
-      expect(error?.reason).toBe("TRANSACTION_DB_ERROR");
-    });
-  });
-
-  describe("listTransactions", () => {
-    it("returns a trimmed page with hasMore and nextOffset", async () => {
-      const txs = [
-        makeTransaction({ id: "tx-1" }),
-        makeTransaction({ id: "tx-2" }),
-        makeTransaction({ id: "tx-3" }),
-      ];
-      mockTransactionRepo.getPage.mockResolvedValue(txs as any);
-
-      const [error, data] = await transactionService.listTransactions("user-1", {
-        year: 2024,
-        month: 0,
-        offset: 5,
-        limit: 2,
-      });
-
-      expect(error).toBeNull();
-      expect(data).toEqual({
-        transactions: txs.slice(0, 2),
-        hasMore: true,
-        nextOffset: 7,
-      });
-      expect(mockTransactionRepo.getPage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          userId: "user-1",
-          offset: 5,
-          limit: 3,
-        }),
-      );
-    });
-
-    it("returns an empty page without nextOffset when repo returns no results", async () => {
-      mockTransactionRepo.getPage.mockResolvedValue([] as any);
-
-      const [error, data] = await transactionService.listTransactions("user-1", {
-        offset: 0,
-        limit: 25,
-      });
-
-      expect(error).toBeNull();
-      expect(data).toEqual({
-        transactions: [],
-        hasMore: false,
-        nextOffset: null,
-      });
-    });
-
-    it("returns TRANSACTION_DB_ERROR when repo throws", async () => {
-      mockTransactionRepo.getPage.mockRejectedValue(new Error("DB error"));
-
-      const [error, data] = await transactionService.listTransactions("user-1", {
-        offset: 0,
-        limit: 25,
-      });
 
       expect(data).toBeNull();
       expect(error?.reason).toBe("TRANSACTION_DB_ERROR");

--- a/apps/web/src/features/transactions/transactions.service.ts
+++ b/apps/web/src/features/transactions/transactions.service.ts
@@ -1,17 +1,8 @@
 import { err, ok } from "@/utils/result";
 import { transactionRepo } from "./transactions.repo";
 import dayjs from "dayjs";
-import {
-  ListTransactionsDTO,
-  NewEntryDTO,
-  UpdateEntryDTO,
-} from "./transactions.dtos";
-import {
-  NewTransaction,
-  Transaction,
-  TransactionKpis,
-  TransactionPage,
-} from "./transactions.models";
+import { GetTransactionsDTO, NewEntryDTO, UpdateEntryDTO } from "./transactions.dtos";
+import { NewTransaction, Transaction, TransactionKpis } from "./transactions.models";
 import { productService } from "../products/products.service";
 import { tagsService } from "../tags/tags.service";
 
@@ -35,45 +26,9 @@ async function getTransactions(userId: string, year?: number, month?: number) {
   }
 }
 
-async function listTransactions(userId: string, input: ListTransactionsDTO) {
-  try {
-    let start: Date;
-    if (input.year === undefined || input.month === undefined) {
-      start = dayjs().startOf("month").toDate();
-    } else {
-      start = new Date(input.year, input.month, 1);
-    }
-
-    const end = dayjs(start).add(1, "month").toDate();
-    const offset = input.offset ?? 0;
-    const limit = input.limit ?? 25;
-    const transactions = await transactionRepo.getPage({
-      userId,
-      start,
-      end,
-      offset,
-      limit: limit + 1,
-    });
-
-    const pageTransactions = transactions.slice(0, limit);
-    const hasMore = transactions.length > limit;
-
-    return ok<TransactionPage>({
-      transactions: pageTransactions,
-      hasMore,
-      nextOffset: hasMore ? offset + pageTransactions.length : null,
-    });
-  } catch (error) {
-    return err({
-      reason: "TRANSACTION_DB_ERROR",
-      message: `Failed to fetch paginated transactions for user ${userId}`,
-    });
-  }
-}
-
 async function getTransactionKpis(
   userId: string,
-  input: Pick<ListTransactionsDTO, "year" | "month">,
+  input: GetTransactionsDTO,
 ) {
   try {
     let start: Date;
@@ -601,7 +556,6 @@ async function resolveProduct(
 
 export const transactionService = {
   getTransactions,
-  listTransactions,
   getTransactionKpis,
   getTransaction,
   saveTransaction,

--- a/apps/web/src/routes/_app/dashboard/transactions/index.tsx
+++ b/apps/web/src/routes/_app/dashboard/transactions/index.tsx
@@ -17,10 +17,10 @@ import { Button } from "@/components/ui/button";
 import { KpiCard } from "@/features/analytics/components/kpi-card";
 import { TransactionList } from "@/features/transactions/components/transaction-list";
 import { transactionQueries } from "@/features/transactions/transactions.queries";
-import { useInfiniteQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowLeftRight, Layers, LoaderCircle, Plus, TrendingUp } from "lucide-react";
-import { Suspense, useEffect, useMemo, useRef } from "react";
+import { ArrowLeftRight, Layers, Plus, TrendingUp } from "lucide-react";
+import { Suspense } from "react";
 
 export const Route = createFileRoute("/_app/dashboard/transactions/")({
   loaderDeps: ({ search: { month, year } }) => ({ month, year }),
@@ -29,8 +29,8 @@ export const Route = createFileRoute("/_app/dashboard/transactions/")({
       context.queryClient.prefetchQuery(
         transactionQueries.getTransactionKpisOptions(deps.year, deps.month),
       ),
-      context.queryClient.prefetchInfiniteQuery(
-        transactionQueries.getTransactionListOptions(deps.year, deps.month),
+      context.queryClient.prefetchQuery(
+        transactionQueries.getTransactionsOptions(deps.year, deps.month),
       ),
     ]);
   },
@@ -82,69 +82,14 @@ function TransactionsContentSkeleton() {
 
 function TransactionsContent() {
   const { year, month } = Route.useSearch();
-  const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const {
     data: [expectedError, kpis],
     error: unexpectedError,
   } = useSuspenseQuery(transactionQueries.getTransactionKpisOptions(year, month));
   const {
-    data: paginatedData,
+    data: [listExpectedError, transactions],
     error: listUnexpectedError,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-    isPending: isListPending,
-  } = useInfiniteQuery(transactionQueries.getTransactionListOptions(year, month));
-
-  const [listExpectedError, transactionPages] = useMemo(() => {
-    if (!paginatedData) {
-      return [null, null] as const;
-    }
-
-    const firstExpectedError = paginatedData.pages
-      .map(([pageError]) => pageError)
-      .find(Boolean);
-
-    if (firstExpectedError) {
-      return [firstExpectedError, null] as const;
-    }
-
-    return [
-      null,
-      paginatedData.pages
-        .map(([, page]) => page)
-        .filter(
-          (page): page is NonNullable<(typeof paginatedData.pages)[number][1]> =>
-            page !== null,
-        ),
-    ] as const;
-  }, [paginatedData]);
-
-  const visibleTransactions = useMemo(
-    () => transactionPages?.flatMap((page) => page.transactions) ?? [],
-    [transactionPages],
-  );
-
-  useEffect(() => {
-    const target = loadMoreRef.current;
-    if (!target || !hasNextPage || isFetchingNextPage || listExpectedError) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const [entry] = entries;
-        if (entry?.isIntersecting) {
-          fetchNextPage();
-        }
-      },
-      { rootMargin: "200px" },
-    );
-
-    observer.observe(target);
-
-    return () => observer.disconnect();
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage, listExpectedError]);
+  } = useSuspenseQuery(transactionQueries.getTransactionsOptions(year, month));
 
   if (unexpectedError || listUnexpectedError) {
     return <UnexpectedError />;
@@ -199,22 +144,7 @@ function TransactionsContent() {
           />
         </div>
       </div>
-      {isListPending ? null : <TransactionList transactions={visibleTransactions} />}
-      <div
-        ref={loadMoreRef}
-        className="flex min-h-10 items-center justify-center"
-      >
-        {isFetchingNextPage ? (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <LoaderCircle className="size-4 animate-spin" />
-            Loading more transactions...
-          </div>
-        ) : visibleTransactions.length > 0 && !hasNextPage ? (
-          <p className="text-sm text-muted-foreground">
-            You have reached the end of the transaction list.
-          </p>
-        ) : null}
-      </div>
+      <TransactionList transactions={transactions ?? []} />
     </div>
   );
 }


### PR DESCRIPTION
Only selects transactions for a given user and month, so won't be too many items, justifying that infinite scroll is not necessary (would be nice, but since it broke the month selector, I removed it for now)